### PR TITLE
Improve CLI guidance for generated dashboard artifacts

### DIFF
--- a/src/backtesting/historical_backtester.py
+++ b/src/backtesting/historical_backtester.py
@@ -308,7 +308,9 @@ class HistoricalRecommendationBacktester:
                 "pre_market_volume": np.nan,
             }
             row["holding_period_days"] = self.engine._estimate_holding_period(row)  # noqa: SLF001
-            row["exit_strategy"] = self.engine._determine_exit_strategy(row)  # noqa: SLF001
+            exit_plan = self.engine._determine_exit_strategy(row)  # noqa: SLF001
+            row.update(exit_plan)
+            row["exit_strategy"] = row.get("exit_plan", "")
             rows.append(row)
 
             histories[symbol] = past


### PR DESCRIPTION
## Summary
- enhance the notebook runner output to surface entry/stop/target, technical drivers, exit plans, and generated artifact paths for each top pick
- update the CLI entry point to mirror the richer top-pick and artifact reporting so users know where to find the HTML dashboard

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d99294d85083268099975b19dee517